### PR TITLE
dispose of subscription when component is unmounting

### DIFF
--- a/scripts/Pinch.js
+++ b/scripts/Pinch.js
@@ -26,6 +26,12 @@ class Pinch extends React.Component {
     this.handlePinch();
   }
 
+  componentWillUnmount() {
+    if (this.pinchSubscription) {
+      this.pinchSubscription.dispose();
+    }
+  }
+
   handlePinch() {
     let touchStart = Rx.Observable.fromEvent(window, 'touchstart');
     let touchMove = Rx.Observable.fromEvent(window, 'touchmove');
@@ -41,7 +47,7 @@ class Pinch extends React.Component {
       })
       .map(logger)
 
-    pinch.subscribe(scale => this.setState({ scale: scale }));
+    this.pinchSubscription = pinch.subscribe(scale => this.setState({ scale: scale }));
   }
 
   render() {


### PR DESCRIPTION
gets pretty messy for me, where the profiler shows something like 2-3MB more memory usage when not disposing of these streams.

i guess RxJS cleans these up by using a ref counter or something so it doesn't just leak? still seems like disposing would be a nice thing to do.
